### PR TITLE
introduce "=" for kinovar and "+" for stretched (wide) text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 dist/
 .DS_Store/
 .coveralls.yml
+.vscode

--- a/README.md
+++ b/README.md
@@ -6,20 +6,17 @@ An extension to `markdown-it` engine that adds Church Slavonic syntax features.
 
 ## Features
 
-### Emphasis becomes red (kinvar color)
+### Use `=` to mark red (kinvar color)
 
-Markdown emphasis is now typeset with red font (not italic).
-
-```
-*Слава и ныне*
-```
-
-### Strong (bold) spans are wide
-
-Markdown string emphasis is typeset with wide font (expanded).
 
 ```
-__Глас а__
+=Слава и ныне=
+```
+
+### Use `+` to mark wide text (stretched)
+
+```
++Глас а+
 ```
 
 ### Leading tilda makes first letter red
@@ -77,4 +74,5 @@ console.log(out)
 
 ## Release notes
 
+* 1.0.0 Changed the way we markup kinovar and wide (to leave bold/italic alone)
 * 0.0.1 Initial release

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,8 @@ module.exports = function church_slavonic_plugin(md, options) {
     require('./verse')
   ).use(
     require('./pagebreak')
+  ).use(
+    require('./kinovar')
   );
 
 };

--- a/lib/kinovar.js
+++ b/lib/kinovar.js
@@ -1,0 +1,88 @@
+'use strict';
+
+function make_tokenize(triggerChar) {
+  return function tokenize(state, silent) {
+    var scanned, token, len, ch,
+        start = state.pos,
+        marker = state.src.charCodeAt(start),
+        triggerCode = triggerChar.charCodeAt(0);
+
+    if (silent) { return false; }
+
+    if (marker !== triggerCode) { return false; }
+
+    scanned = state.scanDelims(state.pos, true);
+    len = scanned.length;
+    ch = String.fromCharCode(marker);
+
+    if (len > 1) { return false; }
+
+    token = state.push('text', '', 0);
+    token.content = ch;
+
+    state.delimiters.push({
+      marker: marker,
+      jump: 0,
+      token: state.tokens.length - 1,
+      level: state.level,
+      end: -1,
+      open: scanned.can_open,
+      close: scanned.can_close
+    });
+
+    state.pos += scanned.length;
+
+    return true;
+  };
+}
+
+
+function make_post_process(triggerChar, tag) {
+
+  return function postProcess(state) {
+    var i,
+        startDelim,
+        endDelim,
+        token,
+        delimiters = state.delimiters,
+        max = state.delimiters.length,
+        triggerCode = triggerChar.charCodeAt(0);
+
+    for (i = 0; i < max; i++) {
+      startDelim = delimiters[i];
+
+      if (startDelim.marker !== triggerCode) {
+        continue;
+      }
+
+      if (startDelim.end === -1) {
+        continue;
+      }
+
+      endDelim = delimiters[startDelim.end];
+
+      token = state.tokens[startDelim.token];
+      token.type = tag + '_open';
+      token.tag = tag;
+      token.nesting = 1;
+      token.markup = triggerChar;
+      token.content = '';
+
+      token = state.tokens[endDelim.token];
+      token.type = tag + '_close';
+      token.tag = tag;
+      token.nesting = -1;
+      token.markup = triggerChar;
+      token.content = '';
+    }
+  };
+}
+
+module.exports = function kinovar_plugin(md) {
+
+  md.inline.ruler.before('emphasis', 'kinovar', make_tokenize('='));
+  md.inline.ruler2.before('emphasis', 'kinovar', make_post_process('=', 'kinovar'));
+
+  md.inline.ruler.before('emphasis', 'wide', make_tokenize('+'));
+  md.inline.ruler2.before('emphasis', 'wide', make_post_process('+', 'wide'));
+};

--- a/lib/redbukva.js
+++ b/lib/redbukva.js
@@ -24,7 +24,11 @@ function make_inline(triggerCharCode, tag) {
     if (
       pos > 0 &&
             state.src.charCodeAt(pos - 1) !== 0x20 &&
-            state.src.charCodeAt(pos - 1) !== 0x0a
+            state.src.charCodeAt(pos - 1) !== 0x0a &&
+            state.src.charCodeAt(pos - 1) !== 0x2a &&  // *
+            state.src.charCodeAt(pos - 1) !== 0x3d &&  // =
+            state.src.charCodeAt(pos - 1) !== 0x2b &&  // +
+            state.src.charCodeAt(pos - 1) !== 0x5f     // _
     ) {
       return false;
     }
@@ -56,6 +60,6 @@ module.exports = function redbukva_plugin(md) {
   var redbukva_inline = make_inline(0x7e /* ~ */, 'redbukva');
   var bukvitsa_inline = make_inline(0x5e /* ^ */, 'bukvitsa');
 
-  md.inline.ruler.before('emphasis', 'redbukva_inline', redbukva_inline);
-  md.inline.ruler.before('emphasis', 'bukvitsa_inline', bukvitsa_inline);
+  md.inline.ruler.after('emphasis', 'redbukva_inline', redbukva_inline);
+  md.inline.ruler.after('emphasis', 'bukvitsa_inline', bukvitsa_inline);
 };

--- a/lib/redbukva.js
+++ b/lib/redbukva.js
@@ -44,6 +44,8 @@ function make_inline(triggerCharCode, tag) {
       return false;
     }
 
+    match = match[0];
+
     if (!silent) {
       state.push(tag + '_open', tag, 1);
       token = state.push('text', '', 0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-church-slavonic",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "description": "Church Slavonic markdown flavor",
   "author": {
     "name": "Mike Kroutikov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-church-slavonic",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Church Slavonic markdown flavor",
   "author": {
     "name": "Mike Kroutikov",

--- a/test/fixtures/emphasis.txt
+++ b/test/fixtures/emphasis.txt
@@ -22,3 +22,17 @@ Hello, **+world+**!
 .
 <p>Hello, <strong><wide>world</wide></strong>!</p>
 .
+
+real life test 1
+.
+~Ѡ҆полчи́шасѧ сы́нове і҆и҃лєвы въ 
+.
+<p><redbukva>Ѡ҆</redbukva>полчи́шасѧ сы́нове і҆и҃лєвы въ</p>
+.
+
+real life test 2
+.
+**~Ѡ҆**полчи́шасѧ сы́нове і҆и҃лєвы въ 
+.
+<p><strong><redbukva>Ѡ҆</redbukva></strong>полчи́шасѧ сы́нове і҆и҃лєвы въ</p>
+.

--- a/test/fixtures/emphasis.txt
+++ b/test/fixtures/emphasis.txt
@@ -4,14 +4,21 @@ desc: emphasis tests
 
 kinovar test
 .
-Hello, *world*!
+Hello, =world=!
 .
-<p>Hello, <em>world</em>!</p>
+<p>Hello, <kinovar>world</kinovar>!</p>
 .
 
-stretch test
+wide test
 .
-Hello, **world**!
+Hello, +world+!
 .
-<p>Hello, <strong>world</strong>!</p>
+<p>Hello, <wide>world</wide>!</p>
+.
+
+mixed test
+.
+Hello, **+world+**!
+.
+<p>Hello, <strong><wide>world</wide></strong>!</p>
 .

--- a/test/fixtures/redbukva.txt
+++ b/test/fixtures/redbukva.txt
@@ -40,3 +40,10 @@ bukvitsa smoke
 .
 <p><bukvitsa>H</bukvitsa>ello, bukvitsa!</p>
 .
+
+redbukva and bold
+.
+**~Hello**
+.
+<p><strong><redbukva>H</redbukva>ello</strong></p>
+.


### PR DESCRIPTION
Changed the markup for kinovar and wide (stretched) text.

This is needed to support both BOLD and KINOVAR in one text. Before this change cu-MD was using
BOLD and ITALIC to mark KINOVAR and WIDE.

New syntax for KINOVAR is:
```
=red=
```

New syntax for WIDE is:
```
+wide+
```